### PR TITLE
Added confirmation prompt to remove-storage-space.ps1

### DIFF
--- a/remove-storage-space.ps1
+++ b/remove-storage-space.ps1
@@ -4,6 +4,13 @@ $SSDTierName = "SSDTier"
 $HDDTierName = "HDDTier"
 $TieredDiskName = "My Tiered VirtualDisk"
 
+# Make sure they really want to do this!
+$choices  = '&Yes', '&No'
+$decision = $Host.UI.PromptForChoice('Remove Storage Space', 'Are you sure you wish to remove the storage space named "' + $TieredDiskName + '"?' + [Environment]::NewLine + 'ALL DATA WILL BE PERMANENTLY LOST', $choices, 1)
+if ($decision -ne 0) {
+    exit
+}
+
 # In reverse order of creation
 if ((Get-VirtualDisk -FriendlyName $TieredDiskName) -ne $null){
     Write-Output "Removing drive: $TieredDiskName"


### PR DESCRIPTION
The script normally does not prompt before deleting the storage space created by new-storage-space.ps1. In my case, I'm using the space to store some important files and others may as well. Added confirmation prompt to remove-storage-space.ps1 to help avoid accidental data loss.